### PR TITLE
Ensure immediate callback on useStateView

### DIFF
--- a/js/src/main/scala/crystal/react/hooks/UseStateView.scala
+++ b/js/src/main/scala/crystal/react/hooks/UseStateView.scala
@@ -15,7 +15,7 @@ object UseStateView {
       .buildReturning { (_, state, delayedCallback) =>
         View[A](
           state.value,
-          (f, cb) => state.modState(f) >> delayedCallback(cb)
+          (f, cb) => delayedCallback(cb) >> state.modState(f)
         )
       }
 


### PR DESCRIPTION
View callbacks are triggered by using the `useStateCallback` mechanism. We were registering the delayed callback after setting the state, which in heavy sections of the UI could result in the callback being performed too late, even with a newer state value than the one originally set.

This PR fixes this by registering the delayed callback before setting the state. This ensures it is triggered as soon as possible. Registering callbacks doesn't trigger a rerender since it's stored via `useRef`.