### PR TITLE
Initialize `Deglitcher` to "now"

### DIFF
--- a/modules/core/shared/src/main/scala/crystal/Deglitcher.scala
+++ b/modules/core/shared/src/main/scala/crystal/Deglitcher.scala
@@ -9,7 +9,6 @@ import cats.syntax.all.*
 import fs2.Pipe
 import fs2.Stream
 
-import scala.concurrent.duration.Duration
 import scala.concurrent.duration.FiniteDuration
 
 final class Deglitcher[F[_]] private (

--- a/modules/core/shared/src/main/scala/crystal/Deglitcher.scala
+++ b/modules/core/shared/src/main/scala/crystal/Deglitcher.scala
@@ -38,5 +38,5 @@ final class Deglitcher[F[_]] private (
 
 object Deglitcher {
   def apply[F[_]](timeout: FiniteDuration)(using F: Temporal[F]): F[Deglitcher[F]] =
-    F.ref(Duration.Zero).map(new Deglitcher(_, timeout))
+    F.monotonic.flatMap(F.ref(_)).map(new Deglitcher(_, timeout))
 }


### PR DESCRIPTION
One last fix. The `monotonic` clock typically starts at `0` on JS, but this is not guaranteed in general. So better to initialize it with the current time.