### PR TITLE
Effect hooks improvements

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 Global / onChangedBuildSource := ReloadOnSourceChanges
 
 ThisBuild / crossScalaVersions := List("3.4.1")
-ThisBuild / tlBaseVersion      := "0.37"
+ThisBuild / tlBaseVersion      := "0.38"
 
 ThisBuild / tlCiReleaseBranches := Seq("master")
 

--- a/modules/core/js/src/main/scala/crystal/react/hooks/UseEffectResult.scala
+++ b/modules/core/js/src/main/scala/crystal/react/hooks/UseEffectResult.scala
@@ -38,14 +38,6 @@ object UseEffectResult {
       /**
        * Runs an async effect and stores the result in a state, which is provided as a `Pot[A]`.
        */
-      final def useEffectResult[A](effect: DefaultA[A])(using
-        step: Step
-      ): step.Next[Pot[A]] =
-        useEffectResultBy(_ => effect)
-
-      /**
-       * Runs an async effect and stores the result in a state, which is provided as a `Pot[A]`.
-       */
       final def useEffectResultOnMount[A](effect: DefaultA[A])(using
         step: Step
       ): step.Next[Pot[A]] =
@@ -63,14 +55,6 @@ object UseEffectResult {
           val hookInstance = hook[D, A]
           hookInstance(WithDeps(deps(ctx), effect(ctx)))
         }
-
-      /**
-       * Runs an async effect and stores the result in a state, which is provided as a `Pot[A]`.
-       */
-      final def useEffectResultBy[A](effect: Ctx => DefaultA[A])(using
-        step: Step
-      ): step.Next[Pot[A]] =
-        useEffectResultWithDepsBy(_ => NeverReuse)(ctx => _ => effect(ctx))
 
       /**
        * Runs an async effect and stores the result in a state, which is provided as a `Pot[A]`.
@@ -94,14 +78,6 @@ object UseEffectResult {
         step: Step
       ): step.Next[Pot[A]] =
         useEffectResultWithDepsBy(step.squash(deps)(_))(step.squash(effect)(_))
-
-      /**
-       * Runs an async effect and stores the result in a state, which is provided as a `Pot[A]`.
-       */
-      final def useEffectResult[A](effect: CtxFn[DefaultA[A]])(using
-        step: Step
-      ): step.Next[Pot[A]] =
-        useEffectResultBy(step.squash(effect)(_))
 
       /**
        * Runs an async effect and stores the result in a state, which is provided as a `Pot[A]`.

--- a/modules/core/js/src/main/scala/crystal/react/hooks/UseEffectStreamResource.scala
+++ b/modules/core/js/src/main/scala/crystal/react/hooks/UseEffectStreamResource.scala
@@ -1,0 +1,305 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package crystal.react.hooks
+
+import cats.effect.Resource
+import cats.syntax.all.*
+import crystal.*
+import crystal.react.*
+import japgolly.scalajs.react.*
+import japgolly.scalajs.react.hooks.CustomHook
+import japgolly.scalajs.react.util.DefaultEffects.Async as DefaultA
+
+object UseEffectStreamResource {
+
+  protected def hook[D: Reusability] = CustomHook[WithDeps[D, StreamResource[Unit]]]
+    .useAsyncEffectWithDepsBy(props => props.deps): props =>
+      deps =>
+        val executingResource: Resource[DefaultA, Unit] =
+          props
+            .fromDeps(deps)
+            .flatMap: stream =>
+              Resource.make(stream.compile.drain.start)(_.cancel).as(())
+        executingResource.allocated.map(_._2) // open the resource and return a close callback
+    .build
+
+  object HooksApiExt {
+    sealed class Primary[Ctx, Step <: HooksApi.AbstractStep](api: HooksApi.Primary[Ctx, Step]) {
+
+      /**
+       * Drain a `fs2.Stream[Async, Unit]` by creating a fiber on each render. If there was another
+       * fiber executing from the previous render, it will be cancelled.
+       */
+      final def useEffectStream(stream: fs2.Stream[DefaultA, Unit])(using step: Step): step.Self =
+        useEffectStreamBy(_ => stream)
+
+      /**
+       * Drain a `fs2.Stream[Async, Unit]` by creating a fiber on mount or when deps change.The
+       * fiber will be cancelled on unmount or deps change.
+       */
+      final def useEffectStreamWithDeps[D: Reusability](deps: => D)(
+        stream: D => fs2.Stream[DefaultA, Unit]
+      )(using step: Step): step.Self =
+        useEffectStreamResourceWithDeps(deps)(deps => Resource.pure(stream(deps)))
+
+      /**
+       * Drain a `fs2.Stream[Async, Unit]` by creating a fiber on mount. The fiber will be cancelled
+       * on unmount.
+       */
+      final def useEffectStreamOnMount(
+        stream: fs2.Stream[DefaultA, Unit]
+      )(using step: Step): step.Self =
+        useEffectStreamResourceOnMount(Resource.pure(stream))
+
+      /**
+       * Drain a `fs2.Stream[Async, Unit]` by creating a fiber when a `Pot` dependency becomes
+       * `Ready`. The fiber will be cancelled on unmount or if the dependency transitions to
+       * `Pending` or `Error`.
+       */
+      def useEffectStreamWhenDepsReady[D](deps: => Pot[D])(stream: D => fs2.Stream[DefaultA, Unit])(
+        using step: Step
+      ): step.Self =
+        useEffectStreamWithDeps(deps.toOption.void)(_ => deps.toOption.map(stream).orEmpty)
+
+      /**
+       * Drain a `fs2.Stream[Async, Unit]` by creating a fiber on each render. If there was another
+       * fiber executing from the previous render, it will be cancelled.
+       */
+      final def useEffectStreamBy(stream: Ctx => fs2.Stream[DefaultA, Unit])(using
+        step: Step
+      ): step.Self =
+        useEffectStreamWithDepsBy(_ => NeverReuse)(ctx => _ => stream(ctx))
+
+      /**
+       * Drain a `fs2.Stream[Async, Unit]` by creating a fiber on mount or when deps change.The
+       * fiber will be cancelled on unmount or deps change.
+       */
+      final def useEffectStreamWithDepsBy[D: Reusability](deps: Ctx => D)(
+        stream: Ctx => D => fs2.Stream[DefaultA, Unit]
+      )(using step: Step): step.Self =
+        useEffectStreamResourceWithDepsBy(deps)(ctx => deps => Resource.pure(stream(ctx)(deps)))
+
+      /**
+       * Drain a `fs2.Stream[Async, Unit]` by creating a fiber on mount. The fiber will be cancelled
+       * on unmount.
+       */
+      final def useEffectStreamOnMountBy(
+        stream: Ctx => fs2.Stream[DefaultA, Unit]
+      )(using step: Step): step.Self =
+        useEffectStreamResourceOnMountBy(ctx => Resource.pure(stream(ctx)))
+
+      /**
+       * Drain a `fs2.Stream[Async, Unit]` by creating a fiber when a `Pot` dependency becomes
+       * `Ready`. The fiber will be cancelled on unmount or if the dependency transitions to
+       * `Pending` or `Error`.
+       */
+      def useEffectStreamWhenDepsReadyBy[D](
+        deps: Ctx => Pot[D]
+      )(stream: Ctx => D => fs2.Stream[DefaultA, Unit])(using
+        step: Step
+      ): step.Self =
+        useEffectStreamWithDepsBy(deps(_).toOption.void)(ctx =>
+          _ => deps(ctx).toOption.map(stream(ctx)).orEmpty
+        )
+
+      /**
+       * Open a `Resource[Async, fs.Stream[Async, Unit]]` on each render, and drain the stream by
+       * creating a fiber. If there was another fiber executing from the previous render, it will be
+       * cancelled and its resource closed.
+       */
+      final def useEffectStreamResource(streamResource: StreamResource[Unit])(using
+        step: Step
+      ): step.Self =
+        useEffectStreamResourceBy(_ => streamResource)
+
+      /**
+       * Open a `Resource[Async, fs.Stream[Async, Unit]]` on mount or when dependencies change, and
+       * drain the stream by creating a fiber. The fiber will be cancelled and the resource closed
+       * on unmount or deps change.
+       */
+      final def useEffectStreamResourceWithDeps[D: Reusability](deps: => D)(
+        streamResource: D => StreamResource[Unit]
+      )(using step: Step): step.Self =
+        useEffectStreamResourceWithDepsBy(_ => deps)(_ => streamResource)
+
+      /**
+       * Open a `Resource[Async, fs.Stream[Async, Unit]]` on mount, and drain the stream by creating
+       * a fiber. The fiber will be cancelled and the resource closed on unmount.
+       */
+      final def useEffectStreamResourceOnMount(
+        streamResource: StreamResource[Unit]
+      )(using step: Step): step.Self =
+        useEffectStreamResourceOnMountBy(_ => streamResource)
+
+      /**
+       * Open a `Resource[Async, fs.Stream[Async, Unit]]` when a `Pot` dependency becomes `Ready`,
+       * and drain the stream by creating a fiber. The fiber will be cancelled and the resource
+       * closed on unmount or if the dependency transitions to `Pending` or `Error`.
+       */
+      final def useEffectStreamResourceWhenDepsReady[D](deps: => Pot[D])(
+        streamResource: D => StreamResource[Unit]
+      )(using step: Step): step.Self =
+        useEffectStreamResourceWithDeps(deps.toOption.void)(_ =>
+          deps.toOption.map(streamResource).orEmpty
+        )
+
+      /**
+       * Open a `Resource[Async, fs.Stream[Async, Unit]]` on each render, and drain the stream by
+       * creating a fiber. If there was another fiber executing from the previous render, it will be
+       * cancelled and its resource closed.
+       */
+      final def useEffectStreamResourceBy(streamResource: Ctx => StreamResource[Unit])(using
+        step: Step
+      ): step.Self =
+        useEffectStreamResourceWithDepsBy(_ => NeverReuse)(ctx => _ => streamResource(ctx))
+
+      /**
+       * Open a `Resource[Async, fs.Stream[Async, Unit]]` on mount or when dependencies change, and
+       * drain the stream by creating a fiber. The fiber will be cancelled and the resource closed
+       * on unmount or deps change.
+       */
+      final def useEffectStreamResourceWithDepsBy[D: Reusability](deps: Ctx => D)(
+        streamResource: Ctx => D => StreamResource[Unit]
+      )(using step: Step): step.Self =
+        api.customBy { ctx =>
+          val hookInstance = hook[D]
+          hookInstance(WithDeps(deps(ctx), streamResource(ctx)))
+        }
+
+      /**
+       * Open a `Resource[Async, fs.Stream[Async, Unit]]` on mount, and drain the stream by creating
+       * a fiber. The fiber will be cancelled and the resource closed on unmount.
+       */
+      final def useEffectStreamResourceOnMountBy(
+        streamResource: Ctx => StreamResource[Unit]
+      )(using step: Step): step.Self = // () has Reusability = always.
+        useEffectStreamResourceWithDepsBy(_ => ())(ctx => _ => streamResource(ctx))
+
+      /**
+       * Open a `Resource[Async, fs.Stream[Async, Unit]]` when a `Pot` dependency becomes `Ready`,
+       * and drain the stream by creating a fiber. The fiber will be cancelled and the resource
+       * closed on unmount or if the dependency transitions to `Pending` or `Error`.
+       */
+      final def useEffectStreamResourceWhenDepsReadyBy[D](deps: Ctx => Pot[D])(
+        streamResource: Ctx => D => StreamResource[Unit]
+      )(using step: Step): step.Self =
+        useEffectStreamResourceWithDepsBy(deps(_).toOption.void)(ctx =>
+          _ => deps(ctx).toOption.map(streamResource(ctx)).orEmpty
+        )
+    }
+
+    final class Secondary[Ctx, CtxFn[_], Step <: HooksApi.SubsequentStep[Ctx, CtxFn]](
+      api: HooksApi.Secondary[Ctx, CtxFn, Step]
+    ) extends Primary[Ctx, Step](api) {
+
+      /**
+       * Drain a `fs2.Stream[Async, Unit]` by creating a fiber on each render. If there was another
+       * fiber executing from the previous render, it will be cancelled.
+       */
+      final def useEffectStreamBy(stream: CtxFn[fs2.Stream[DefaultA, Unit]])(using
+        step: Step
+      ): step.Self =
+        useEffectStreamWithDepsBy(_ => NeverReuse)(ctx => _ => step.squash(stream)(ctx))
+
+      /**
+       * Drain a `fs2.Stream[Async, Unit]` by creating a fiber on mount or when deps change.The
+       * fiber will be cancelled on unmount or deps change.
+       */
+      final def useEffectStreamWithDepsBy[D: Reusability](deps: CtxFn[D])(
+        stream: CtxFn[D => fs2.Stream[DefaultA, Unit]]
+      )(using step: Step): step.Self =
+        useEffectStreamResourceWithDepsBy(step.squash(deps)(_))(ctx =>
+          deps => Resource.pure(step.squash(stream)(ctx)(deps))
+        )
+
+      /**
+       * Drain a `fs2.Stream[Async, Unit]` by creating a fiber on mount. The fiber will be cancelled
+       * on unmount.
+       */
+      final def useEffectStreamOnMountBy(
+        stream: CtxFn[fs2.Stream[DefaultA, Unit]]
+      )(using step: Step): step.Self =
+        useEffectStreamResourceOnMountBy((ctx: Ctx) =>
+          Resource.pure[DefaultA, fs2.Stream[DefaultA, Unit]](step.squash(stream)(ctx))
+        )
+
+      /**
+       * Drain a `fs2.Stream[Async, Unit]` by creating a fiber when a `Pot` dependency becomes
+       * `Ready`. The fiber will be cancelled on unmount or if the dependency transitions to
+       * `Pending` or `Error`.
+       */
+      def useEffectStreamWhenDepsReadyBy[D](
+        deps: CtxFn[Pot[D]]
+      )(stream: CtxFn[D => fs2.Stream[DefaultA, Unit]])(using
+        step: Step
+      ): step.Self =
+        useEffectStreamWithDepsBy(step.squash(deps)(_).toOption.void)(ctx =>
+          _ =>
+            step
+              .squash(deps)(ctx)
+              .toOption
+              .map(readyDeps => step.squash(stream)(ctx)(readyDeps))
+              .orEmpty
+        )
+
+      /**
+       * Open a `Resource[Async, fs.Stream[Async, Unit]]` on mount or when dependencies change, and
+       * drain the stream by creating a fiber. The fiber will be cancelled and the resource closed
+       * on unmount or deps change.
+       */
+      final def useEffectStreamResourceWithDepsBy[D: Reusability](deps: CtxFn[D])(
+        streamResource: CtxFn[D => StreamResource[Unit]]
+      )(using step: Step): step.Self =
+        useEffectStreamResourceWithDepsBy(step.squash(deps)(_))(step.squash(streamResource)(_))
+
+      /**
+       * Open a `Resource[Async, fs.Stream[Async, Unit]]` on mount, and drain the stream by creating
+       * a fiber. The fiber will be cancelled and the resource closed on unmount.
+       */
+      final def useEffectStreamResourceOnMountBy(
+        streamResource: CtxFn[StreamResource[Unit]]
+      )(using step: Step): step.Self =
+        useEffectStreamResourceOnMountBy(step.squash(streamResource)(_))
+
+      /**
+       * Open a `Resource[Async, fs.Stream[Async, Unit]]` when a `Pot` dependency becomes `Ready`,
+       * and drain the stream by creating a fiber. The fiber will be cancelled and the resource
+       * closed on unmount or if the dependency transitions to `Pending` or `Error`.
+       */
+      def useEffectStreamResourceWhenDepsReadyBy[D](
+        deps: CtxFn[Pot[D]]
+      )(stream: CtxFn[D => StreamResource[Unit]])(using
+        step: Step
+      ): step.Self =
+        useEffectStreamResourceWithDepsBy(step.squash(deps)(_).toOption.void)(ctx =>
+          _ =>
+            step
+              .squash(deps)(ctx)
+              .toOption
+              .map(readyDeps => step.squash(stream)(ctx)(readyDeps))
+              .orEmpty
+        )
+    }
+  }
+
+  protected trait HooksApiExt {
+    import HooksApiExt.*
+
+    implicit def hooksExtEffectStreamResourceView1[Ctx, Step <: HooksApi.AbstractStep](
+      api: HooksApi.Primary[Ctx, Step]
+    ): Primary[Ctx, Step] =
+      new Primary(api)
+
+    implicit def hooksExtEffectStreamResourceView2[
+      Ctx,
+      CtxFn[_],
+      Step <: HooksApi.SubsequentStep[Ctx, CtxFn]
+    ](
+      api: HooksApi.Secondary[Ctx, CtxFn, Step]
+    ): Secondary[Ctx, CtxFn, Step] =
+      new Secondary(api)
+  }
+
+  object syntax extends HooksApiExt
+}

--- a/modules/core/js/src/main/scala/crystal/react/hooks/UseEffectWhenDepsReady.scala
+++ b/modules/core/js/src/main/scala/crystal/react/hooks/UseEffectWhenDepsReady.scala
@@ -16,7 +16,7 @@ import japgolly.scalajs.react.util.DefaultEffects.Async as DefaultA
 object UseEffectWhenDepsReady:
   def hook[D, A: UseEffectArg: Monoid] =
     CustomHook[WithPotDeps[D, A]]
-      .useEffectWithDepsBy(props => props.deps.void)(props =>
+      .useEffectWithDepsBy(props => props.deps.toOption.void)(props =>
         _ => props.deps.toOption.map(props.fromDeps).orEmpty
       )
       .build
@@ -42,7 +42,7 @@ object UseEffectWhenDepsReady:
       )(effect: D => A)(using
         step: Step
       ): step.Self =
-        useEffectWhenDepsReady(_ => deps)(_ => effect)
+        useEffectWhenDepsReadyBy(_ => deps)(_ => effect)
 
       /**
        * Effect that runs when `Pot` dependencies transition into a `Ready` state. For multiple
@@ -50,7 +50,7 @@ object UseEffectWhenDepsReady:
        * effect bulding function. Returning a cleanup callback is supported, but when using an async
        * effect with cleanup use `useAsyncEffectWhenDepsReady` instead.
        */
-      final def useEffectWhenDepsReady[D, A: UseEffectArg: Monoid](
+      final def useEffectWhenDepsReadyBy[D, A: UseEffectArg: Monoid](
         deps: Ctx => Pot[D]
       )(effect: Ctx => D => A)(using
         step: Step
@@ -70,14 +70,14 @@ object UseEffectWhenDepsReady:
       )(effect: D => DefaultA[DefaultA[Unit]])(using
         step: Step
       ): step.Self =
-        useAsyncEffectWhenDepsReady(_ => deps)(_ => effect)
+        useAsyncEffectWhenDepsReadyBy(_ => deps)(_ => effect)
 
       /**
        * Async effect that runs when `Pot` dependencies transition into a `Ready` state and returns
        * a cleanup callback. For multiple dependencies, use `(par1, par2, ...).tupled`. Dependencies
        * are passed unpacked to the effect bulding function.
        */
-      final def useAsyncEffectWhenDepsReady[D](
+      final def useAsyncEffectWhenDepsReadyBy[D](
         deps: Ctx => Pot[D]
       )(effect: Ctx => D => DefaultA[DefaultA[Unit]])(using
         step: Step
@@ -98,24 +98,24 @@ object UseEffectWhenDepsReady:
        * effect bulding function. Returning a cleanup callback is supported, but when using an async
        * effect with cleanup use `useAsyncEffectWhenDepsReady` instead.
        */
-      def useEffectWhenDepsReady[D, A: UseEffectArg: Monoid](
+      def useEffectWhenDepsReadyBy[D, A: UseEffectArg: Monoid](
         deps: CtxFn[Pot[D]]
       )(effect: CtxFn[D => A])(using
         step: Step
       ): step.Self =
-        useEffectWhenDepsReady(step.squash(deps)(_))(step.squash(effect)(_))
+        useEffectWhenDepsReadyBy(step.squash(deps)(_))(step.squash(effect)(_))
 
       /**
        * Async effect that runs when `Pot` dependencies transition into a `Ready` state and returns
        * a cleanup callback. For multiple dependencies, use `(par1, par2, ...).tupled`. Dependencies
        * are passed unpacked to the effect bulding function.
        */
-      def useAsyncEffectWhenDepsReady[D](
+      def useAsyncEffectWhenDepsReadyBy[D](
         deps: CtxFn[Pot[D]]
       )(effect: CtxFn[D => DefaultA[DefaultA[Unit]]])(using
         step: Step
       ): step.Self =
-        useAsyncEffectWhenDepsReady(step.squash(deps)(_))(step.squash(effect)(_))
+        useAsyncEffectWhenDepsReadyBy(step.squash(deps)(_))(step.squash(effect)(_))
     }
   }
 

--- a/modules/core/js/src/main/scala/crystal/react/hooks/package.scala
+++ b/modules/core/js/src/main/scala/crystal/react/hooks/package.scala
@@ -13,10 +13,9 @@ import japgolly.scalajs.react.util.DefaultEffects.Async as DefaultA
 export UseSingleEffect.syntax.*, UseSerialState.syntax.*, UseStateCallback.syntax.*,
   UseStateView.syntax.*, UseStateViewWithReuse.syntax.*, UseSerialStateView.syntax.*,
   UseAsyncEffect.syntax.*, UseEffectResult.syntax.*, UseResource.syntax.*,
-  UseStreamResource.syntax.*, UseEffectWhenDepsReady.syntax.*
+  UseStreamResource.syntax.*, UseEffectWhenDepsReady.syntax.*, UseEffectStreamResource.syntax.*
 
 type UnitFiber[F[_]] = Fiber[F, Throwable, Unit]
-type AsyncUnitFiber  = Fiber[DefaultA, Throwable, Unit]
 
 type StreamResource[A] = Resource[DefaultA, fs2.Stream[DefaultA, A]]
 


### PR DESCRIPTION
- Update documentation.
- Remove inviable versions of `useEffectResult`.
- Implement `useEffectStream*` family of hooks, which just executes a `fs2.Stream[IO, Unit]`. This is what we want a lot of times, since we just run an effect on each stream element. By using this hook we ensure that execution and cleanup are done when we want.
- Reimplement `useStream*` in terms of `useEffectStream*`, which is more appropriate than `useResource`.
- Add `*whenDepsReady` variants.