### PR TITLE
useAsyncEffect now avoids race conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,24 +199,30 @@ Note that multiple `Pot` dependencies can be combined into one with `.tupled`.
 
 ### useAsyncEffect
 
-Version of `useEffect` that allows defining an async effect with an (also async) cleanup effect.
+Version of `useEffect` that avoids race conditions when executing async effects. This is achieved by cancelling the previous instance of the effect before executing a new one.
 
-`useEffect` allows defining a cleanup effect only when used with the default sync effect (usually `CallbackTo`).
-
-This hook should only be used when a cleanup effect is needed. To use a regular async effect, just use regular `useEffect`.
+Also allows returning a cleanup effect, which `useEffect` only supports when used with the default sync effect (usually `CallbackTo`).
 
 ``` scala
-  useAsyncEffect(effect: IO[IO[Unit]])
-  useAsyncEffectBy(effect: Ctx => IO[IO[Unit]])
+  useAsyncEffect(effect: IO[Unit])
+  useAsyncEffect(effect: IO[IO[Unit]])  // return a cleanup effect
+  useAsyncEffectBy(effect: Ctx => IO[Unit])
+  useAsyncEffectBy(effect: Ctx => IO[IO[Unit]]) // return a cleanup effect
 
-  useAsyncEffectWithDeps[D: Reusability](deps: => D)(effect: D => IO[IO[Unit]])
-  useAsyncEffectWithDepsBy[D: Reusability](deps: Ctx => D)(effect: Ctx => D => IO[IO[Unit]])
+  useAsyncEffectWithDeps[D: Reusability](deps: => D)(effect: D => IO[Unit])
+  useAsyncEffectWithDeps[D: Reusability](deps: => D)(effect: D => IO[IO[Unit]]) // return a cleanup effect
+  useAsyncEffectWithDepsBy[D: Reusability](deps: Ctx => D)(effect: Ctx => D => IO[Unit])
+  useAsyncEffectWithDepsBy[D: Reusability](deps: Ctx => D)(effect: Ctx => D => IO[IO[Unit]]) // return a cleanup effect
 
   useAsyncEffectOnMount(effect: IO[IO[Unit]])
-  useAsyncEffectOnMountBy(effect: Ctx => IO[IO[Unit]])
+  useAsyncEffectOnMount(effect: IO[Unit]) // return a cleanup effect
+  useAsyncEffectOnMountBy(effect: Ctx => IO[Unit])
+  useAsyncEffectOnMountBy(effect: Ctx => IO[IO[Unit]]) // return a cleanup effect
 
-  useAsyncEffectWhenDepsReady[D](deps: => Pot[D])(effect: D => IO[IO[Unit]]) // return cleanup
-  useAsyncEffectWhenDepsReadyBy[D](deps: Ctx => Pot[D])(effect: Ctx => D => IO[IO[Unit]]) // return cleanup
+  useAsyncEffectWhenDepsReady[D](deps: => Pot[D])(effect: D => IO[Unit])
+  useAsyncEffectWhenDepsReady[D](deps: => Pot[D])(effect: D => IO[IO[Unit]]) // return a cleanup effect
+  useAsyncEffectWhenDepsReadyBy[D](deps: Ctx => Pot[D])(effect: Ctx => D => IO[Unit])
+  useAsyncEffectWhenDepsReadyBy[D](deps: Ctx => Pot[D])(effect: Ctx => D => IO[IO[Unit]]) // return a cleanup effect
 ```
 
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 Global / onChangedBuildSource := ReloadOnSourceChanges
 
 ThisBuild / crossScalaVersions := List("3.4.2")
-ThisBuild / tlBaseVersion      := "0.38"
+ThisBuild / tlBaseVersion      := "0.39"
 
 ThisBuild / tlCiReleaseBranches := Seq("master")
 

--- a/modules/core/js/src/main/scala/crystal/react/hooks/EffectWithCleanup.scala
+++ b/modules/core/js/src/main/scala/crystal/react/hooks/EffectWithCleanup.scala
@@ -1,0 +1,22 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package crystal.react.hooks
+
+import japgolly.scalajs.react.util.DefaultEffects.Async as DefaultA
+import cats.Applicative
+
+// Typeclass for normalizing effects into an effect that returns a cleanup effect.
+opaque type EffectWithCleanup[G, F[_]] = G => F[F[Unit]]
+
+object EffectWithCleanup:
+  // Effect already returns a cleanup effect, return as is.
+  given effectWithNoCleanup: EffectWithCleanup[DefaultA[DefaultA[Unit]], DefaultA] =
+    identity
+
+  // Effect doesn't return a cleanup effect, add a no-op cleanup.
+  given effectWithCleanup: EffectWithCleanup[DefaultA[Unit], DefaultA] =
+    _.as(Applicative[DefaultA].unit)
+
+extension [G, F[_]](effect: G)(using effectWithCleanup: EffectWithCleanup[G, F])
+  def normalize: F[F[Unit]] = effectWithCleanup(effect)

--- a/modules/core/js/src/main/scala/crystal/react/hooks/EffectWithCleanup.scala
+++ b/modules/core/js/src/main/scala/crystal/react/hooks/EffectWithCleanup.scala
@@ -3,8 +3,8 @@
 
 package crystal.react.hooks
 
-import japgolly.scalajs.react.util.DefaultEffects.Async as DefaultA
 import cats.Applicative
+import japgolly.scalajs.react.util.DefaultEffects.Async as DefaultA
 
 // Typeclass for normalizing effects into an effect that returns a cleanup effect.
 opaque type EffectWithCleanup[G, F[_]] = G => F[F[Unit]]

--- a/modules/core/js/src/main/scala/crystal/react/hooks/UseAsyncEffect.scala
+++ b/modules/core/js/src/main/scala/crystal/react/hooks/UseAsyncEffect.scala
@@ -4,10 +4,10 @@
 package crystal.react.hooks
 
 import crystal.react.*
+import crystal.react.reuse.*
 import japgolly.scalajs.react.*
 import japgolly.scalajs.react.hooks.CustomHook
 import japgolly.scalajs.react.util.DefaultEffects.Async as DefaultA
-import crystal.react.reuse.*
 
 object UseAsyncEffect {
   def hook[G, D: Reusability](using EffectWithCleanup[G, DefaultA]) =
@@ -18,15 +18,10 @@ object UseAsyncEffect {
 
   object HooksApiExt {
     sealed class Primary[Ctx, Step <: HooksApi.AbstractStep](api: HooksApi.Primary[Ctx, Step]) {
-      // TODO UPDATE SCALADOCS!!!
-      // TODO UPDATE SCALADOCS!!!
-      // TODO UPDATE SCALADOCS!!!
-      // TODO UPDATE SCALADOCS!!!
-      // TODO UPDATE SCALADOCS!!!
 
       /**
-       * Simulates `useEffect` with cleanup callback for async effect. To declare an async effect
-       * without a cleanup callback, just use the regular `useEffect` hook.
+       * Run async effect and cancel previously running instances, thus avoiding race conditions.
+       * Allows returning a cleanup effect.
        */
       final def useAsyncEffectWithDeps[G, D: Reusability](deps: => D)(effect: D => G)(using
         step: Step,
@@ -35,8 +30,8 @@ object UseAsyncEffect {
         useAsyncEffectWithDepsBy(_ => deps)(_ => effect)
 
       /**
-       * Simulates `useEffect` with cleanup callback for async effect. To declare an async effect
-       * without a cleanup callback, just use the regular `useEffect` hook.
+       * Run async effect and cancel previously running instances, thus avoiding race conditions.
+       * Allows returning a cleanup effect.
        */
       final def useAsyncEffect[G](effect: G)(using
         step: Step,
@@ -45,8 +40,8 @@ object UseAsyncEffect {
         useAsyncEffectBy(_ => effect)
 
       /**
-       * Simulates `useEffect` with cleanup callback for async effect. To declare an async effect
-       * without a cleanup callback, just use the regular `useEffect` hook.
+       * Run async effect and cancel previously running instances, thus avoiding race conditions.
+       * Allows returning a cleanup effect.
        */
       final def useAsyncEffectOnMount[G](effect: G)(using
         step: Step,
@@ -55,8 +50,8 @@ object UseAsyncEffect {
         useAsyncEffectOnMountBy(_ => effect)
 
       /**
-       * Simulates `useEffect` with cleanup callback for async effect. To declare an async effect
-       * without a cleanup callback, just use the regular `useEffect` hook.
+       * Run async effect and cancel previously running instances, thus avoiding race conditions.
+       * Allows returning a cleanup effect.
        */
       final def useAsyncEffectWithDepsBy[G, D: Reusability](deps: Ctx => D)(effect: Ctx => D => G)(
         using
@@ -69,8 +64,8 @@ object UseAsyncEffect {
         }
 
       /**
-       * Simulates `useEffect` with cleanup callback for async effect. To declare an async effect
-       * without a cleanup callback, just use the regular `useEffect` hook.
+       * Run async effect and cancel previously running instances, thus avoiding race conditions.
+       * Allows returning a cleanup effect.
        */
       final def useAsyncEffectBy[G](effect: Ctx => G)(using
         step: Step,
@@ -79,8 +74,8 @@ object UseAsyncEffect {
         useAsyncEffectWithDepsBy(_ => NeverReuse)(ctx => (_: Reuse[Unit]) => effect(ctx))
 
       /**
-       * Simulates `useEffect` with cleanup callback for async effect. To declare an async effect
-       * without a cleanup callback, just use the regular `useEffect` hook.
+       * Run async effect and cancel previously running instances, thus avoiding race conditions.
+       * Allows returning a cleanup effect.
        */
       final def useAsyncEffectOnMountBy[G](effect: Ctx => G)(using
         step: Step,
@@ -94,8 +89,8 @@ object UseAsyncEffect {
     ) extends Primary[Ctx, Step](api) {
 
       /**
-       * Simulates `useEffect` with cleanup callback for async effect. To declare an async effect
-       * without a cleanup callback, just use the regular `useEffect` hook.
+       * Run async effect and cancel previously running instances, thus avoiding race conditions.
+       * Allows returning a cleanup effect.
        */
       def useAsyncEffectWithDepsBy[G, D: Reusability](deps: CtxFn[D])(effect: CtxFn[D => G])(using
         step: Step,
@@ -104,8 +99,8 @@ object UseAsyncEffect {
         useAsyncEffectWithDepsBy(step.squash(deps)(_))(step.squash(effect)(_))
 
       /**
-       * Simulates `useEffect` with cleanup callback for async effect. To declare an async effect
-       * without a cleanup callback, just use the regular `useEffect` hook.
+       * Run async effect and cancel previously running instances, thus avoiding race conditions.
+       * Allows returning a cleanup effect.
        */
       def useAsyncEffectBy[G](
         effect: CtxFn[G]
@@ -113,8 +108,8 @@ object UseAsyncEffect {
         useAsyncEffectBy(step.squash(effect)(_))
 
       /**
-       * Simulates `useEffect` with cleanup callback for async effect. To declare an async effect
-       * without a cleanup callback, just use the regular `useEffect` hook.
+       * Run async effect and cancel previously running instances, thus avoiding race conditions.
+       * Allows returning a cleanup effect.
        */
       def useAsyncEffectOnMountBy[G](effect: CtxFn[G])(using
         step: Step,

--- a/modules/core/js/src/main/scala/crystal/react/hooks/UseEffectResult.scala
+++ b/modules/core/js/src/main/scala/crystal/react/hooks/UseEffectResult.scala
@@ -13,7 +13,7 @@ object UseEffectResult {
   def hook[D: Reusability, A] = CustomHook[WithDeps[D, DefaultA[A]]]
     .useState(Pot.pending[A])
     .useEffectWithDepsBy((props, _) => props.deps)((_, state) => _ => state.setState(Pot.pending))
-    .useEffectWithDepsBy((props, _) => props.deps)((props, state) =>
+    .useAsyncEffectWithDepsBy((props, _) => props.deps)((props, state) =>
       deps =>
         (for {
           a <- props.fromDeps(deps)

--- a/modules/core/js/src/main/scala/crystal/react/hooks/UseEffectResult.scala
+++ b/modules/core/js/src/main/scala/crystal/react/hooks/UseEffectResult.scala
@@ -13,13 +13,12 @@ object UseEffectResult {
   def hook[D: Reusability, A] = CustomHook[WithDeps[D, DefaultA[A]]]
     .useState(Pot.pending[A])
     .useEffectWithDepsBy((props, _) => props.deps)((_, state) => _ => state.setState(Pot.pending))
-    .useAsyncEffectWithDepsBy((props, _) => props.deps)((props, state) =>
+    .useAsyncEffectWithDepsBy((props, _) => props.deps): (props, state) =>
       deps =>
         (for {
           a <- props.fromDeps(deps)
           _ <- state.setStateAsync(a.ready)
         } yield ()).handleErrorWith(t => state.setStateAsync(Pot.error(t)))
-    )
     .buildReturning((_, state) => state.value)
 
   object HooksApiExt {

--- a/modules/core/js/src/main/scala/crystal/react/hooks/UseEffectStreamResource.scala
+++ b/modules/core/js/src/main/scala/crystal/react/hooks/UseEffectStreamResource.scala
@@ -57,8 +57,10 @@ object UseEffectStreamResource {
        * `Ready`. The fiber will be cancelled on unmount or if the dependency transitions to
        * `Pending` or `Error`.
        */
-      def useEffectStreamWhenDepsReady[D](deps: => Pot[D])(stream: D => fs2.Stream[DefaultA, Unit])(
-        using step: Step
+      final def useEffectStreamWhenDepsReady[D](
+        deps: => Pot[D]
+      )(stream: D => fs2.Stream[DefaultA, Unit])(using
+        step: Step
       ): step.Self =
         useEffectStreamWithDeps(deps.toOption.void)(_ => deps.toOption.map(stream).orEmpty)
 
@@ -94,7 +96,7 @@ object UseEffectStreamResource {
        * `Ready`. The fiber will be cancelled on unmount or if the dependency transitions to
        * `Pending` or `Error`.
        */
-      def useEffectStreamWhenDepsReadyBy[D](
+      final def useEffectStreamWhenDepsReadyBy[D](
         deps: Ctx => Pot[D]
       )(stream: Ctx => D => fs2.Stream[DefaultA, Unit])(using
         step: Step
@@ -229,7 +231,7 @@ object UseEffectStreamResource {
        * `Ready`. The fiber will be cancelled on unmount or if the dependency transitions to
        * `Pending` or `Error`.
        */
-      def useEffectStreamWhenDepsReadyBy[D](
+      final def useEffectStreamWhenDepsReadyBy[D](
         deps: CtxFn[Pot[D]]
       )(stream: CtxFn[D => fs2.Stream[DefaultA, Unit]])(using
         step: Step
@@ -267,7 +269,7 @@ object UseEffectStreamResource {
        * and drain the stream by creating a fiber. The fiber will be cancelled and the resource
        * closed on unmount or if the dependency transitions to `Pending` or `Error`.
        */
-      def useEffectStreamResourceWhenDepsReadyBy[D](
+      final def useEffectStreamResourceWhenDepsReadyBy[D](
         deps: CtxFn[Pot[D]]
       )(stream: CtxFn[D => StreamResource[Unit]])(using
         step: Step

--- a/modules/core/js/src/main/scala/crystal/react/hooks/UseResource.scala
+++ b/modules/core/js/src/main/scala/crystal/react/hooks/UseResource.scala
@@ -13,7 +13,7 @@ import japgolly.scalajs.react.util.DefaultEffects.Async as DefaultA
 object UseResource {
   def hook[D: Reusability, A] = CustomHook[WithDeps[D, Resource[DefaultA, A]]]
     .useState(Pot.pending[A])
-    .useAsyncEffectWithDepsBy((props, _) => props.deps)((props, state) =>
+    .useAsyncEffectWithDepsBy((props, _) => props.deps): (props, state) =>
       deps =>
         (for {
           resource      <- props.fromDeps(deps).allocated
@@ -21,7 +21,6 @@ object UseResource {
           _             <- state.setStateAsync(value.ready)
         } yield close)
           .handleErrorWith(t => state.setStateAsync(Pot.error(t)).as(DefaultA.delay(())))
-    )
     .buildReturning((_, state) => state.value)
 
   object HooksApiExt {

--- a/modules/core/js/src/main/scala/crystal/react/hooks/UseStateCallback.scala
+++ b/modules/core/js/src/main/scala/crystal/react/hooks/UseStateCallback.scala
@@ -15,17 +15,15 @@ object UseStateCallback {
     CustomHook[Hooks.UseState[A]]
       .useRef(Queue.empty[A => DefaultS[Unit]])
       // Credit to japgolly for this implementation; this is copied from StateSnapshot.
-      .useEffectBy { (state, delayedCallbacks) =>
+      .useEffectBy: (state, delayedCallbacks) =>
         val cbs = delayedCallbacks.value
         if (cbs.isEmpty)
           DefaultS.empty
         else
           delayedCallbacks.set(Queue.empty) >>
             DefaultS.runAll(cbs.toList.map(_(state.value))*)
-      }
-      .buildReturning((_, delayedCallbacks) =>
+      .buildReturning: (_, delayedCallbacks) =>
         (cb: A => DefaultS[Unit]) => delayedCallbacks.mod(_.enqueue(cb))
-      )
 
   object HooksApiExt {
     sealed class Primary[Ctx, Step <: HooksApi.AbstractStep](api: HooksApi.Primary[Ctx, Step]) {

--- a/modules/core/js/src/main/scala/crystal/react/hooks/UseStateView.scala
+++ b/modules/core/js/src/main/scala/crystal/react/hooks/UseStateView.scala
@@ -12,12 +12,11 @@ object UseStateView {
     CustomHook[A]
       .useStateBy(initialValue => initialValue)
       .useStateCallbackBy((_, state) => state)
-      .buildReturning { (_, state, delayedCallback) =>
+      .buildReturning: (_, state, delayedCallback) =>
         View[A](
           state.value,
           (f, cb) => delayedCallback(cb) >> state.modState(f)
         )
-      }
 
   object HooksApiExt {
     sealed class Primary[Ctx, Step <: HooksApi.AbstractStep](api: HooksApi.Primary[Ctx, Step]) {


### PR DESCRIPTION
`useAsyncEffect` now supports async effect with or without cleanup. Its semantics have now changed so that previously running instances are now cancelled before spawning a new instance. It uses `useSingleEffect` internally, which now has the ability to receive a cleanup function.

`useEffectResult` now correctly uses `useAsyncEffect`. The previous implementation was buggy in case different instances finished out of order.