### PR TITLE
Stable callbacks

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 Global / onChangedBuildSource := ReloadOnSourceChanges
 
 ThisBuild / crossScalaVersions := List("3.4.2")
-ThisBuild / tlBaseVersion      := "0.39"
+ThisBuild / tlBaseVersion      := "0.40"
 
 ThisBuild / tlCiReleaseBranches := Seq("master")
 

--- a/modules/core/js/src/main/scala/crystal/react/hooks/UseEffectStreamResource.scala
+++ b/modules/core/js/src/main/scala/crystal/react/hooks/UseEffectStreamResource.scala
@@ -13,16 +13,17 @@ import japgolly.scalajs.react.util.DefaultEffects.Async as DefaultA
 
 object UseEffectStreamResource {
 
-  protected def hook[D: Reusability] = CustomHook[WithDeps[D, StreamResource[Unit]]]
-    .useAsyncEffectWithDepsBy(props => props.deps): props =>
-      deps =>
-        val executingResource: Resource[DefaultA, Unit] =
+  protected def hook[D: Reusability] =
+    CustomHook[WithDeps[D, StreamResource[Unit]]]
+      .useAsyncEffectWithDepsBy(props => props.deps): props =>
+        deps =>
           props
             .fromDeps(deps)
             .flatMap: stream =>
-              Resource.make(stream.compile.drain.start)(_.cancel).as(())
-        executingResource.allocated.map(_._2) // open the resource and return a close callback
-    .build
+              stream.compile.drain.background.void
+            .allocated
+            .map(_._2) // open the resource and return a close callback
+      .build
 
   object HooksApiExt {
     sealed class Primary[Ctx, Step <: HooksApi.AbstractStep](api: HooksApi.Primary[Ctx, Step]) {

--- a/modules/core/shared/src/main/scala/crystal/viewF.scala
+++ b/modules/core/shared/src/main/scala/crystal/viewF.scala
@@ -112,7 +112,7 @@ class ViewF[F[_]: Monad, A](val get: A, val modCB: (A => A, A => F[Unit]) => F[U
 
   def mapValue[B, C](f: ViewF[F, B] => C)(using ev: A =:= Option[B]): Option[C] =
     // _.get is safe here since it's only being called when the value is defined.
-    // The zoom getter function is stored to use in callbacks, se we have to pass _.get
+    // The zoom getter function is stored to use in callbacks, so we have to pass _.get
     // instead of capturing the value here. Otherwise, callbacks see a stale value.
     get.map(_ => f(zoom(_.get)(f => a1 => ev.flip(a1.map(f)))))
 
@@ -122,7 +122,7 @@ class ViewF[F[_]: Monad, A](val get: A, val modCB: (A => A, A => F[Unit]) => F[U
   @targetName("mapValuePot")
   def mapValue[B, C](f: ViewF[F, B] => C)(using ev: A =:= Pot[B]): Pot[C] =
     // _.get is safe here since it's only being called when the value is defined.
-    // The zoom getter function is stored to use in callbacks, se we have to pass _.get
+    // The zoom getter function is stored to use in callbacks, so we have to pass _.get
     // instead of capturing the value here. Otherwise, callbacks see a stale value.
     get.map(_ => f(zoom(_.toOption.get)(f => a1 => ev.flip(a1.map(f)))))
 


### PR DESCRIPTION
This PR makes the state modification function in `useStateView` stable. The same for the `useStateCallback` invocation function.

There are couple of minor improvements too.