### PR TITLE
Views now remember previous values

### DIFF
--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,3 +1,4 @@
 include ".scalafix-common.conf"
 
 OrganizeImports.removeUnused = false
+OrganizeImports.targetDialect = Scala3

--- a/README.md
+++ b/README.md
@@ -101,6 +101,16 @@ ScalaFnComponent
   // Previous `longRunningEffect` is cancelled immediately and new one is ran after 1 second
 ```
 
+### useShadowRef
+
+When passed a value, this hooks keeps the value in a ref with the latest value, and returning a read-only ref.
+
+This is useful when a stable callback (as those created by `useCallback`) wants to access a value that can change, but we don't want to redefine the callback in each render.
+
+``` scala
+  useShadowRef[A](value: Ctx => A): NonEmptyRef.Get[A]
+```
+
 ### useStateCallback
 
 Class components allow us to specify a callback when we modify state. The callback is executed when state is modified and is passed the new state value.

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 Global / onChangedBuildSource := ReloadOnSourceChanges
 
 ThisBuild / crossScalaVersions := List("3.4.2")
-ThisBuild / tlBaseVersion      := "0.40"
+ThisBuild / tlBaseVersion      := "0.41"
 
 ThisBuild / tlCiReleaseBranches := Seq("master")
 

--- a/modules/core/js/src/main/scala/crystal/react/hooks/UseShadowRef.scala
+++ b/modules/core/js/src/main/scala/crystal/react/hooks/UseShadowRef.scala
@@ -1,0 +1,62 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package crystal.react.hooks
+
+import japgolly.scalajs.react.*
+import japgolly.scalajs.react.hooks.CustomHook
+import japgolly.scalajs.react.hooks.Hooks
+import japgolly.scalajs.react.util.DefaultEffects.Sync as DefaultS
+
+object UseShadowRef {
+  def hook[A]: CustomHook[A, NonEmptyRef.Get[A]] =
+    CustomHook[A]
+      .useRefBy(identity) // current
+      .useEffectBy: (value, currentRef) =>
+        currentRef.set(value)
+      .buildReturning: (_, currentRef) =>
+        currentRef
+
+  object HooksApiExt {
+    sealed class Primary[Ctx, Step <: HooksApi.AbstractStep](api: HooksApi.Primary[Ctx, Step]) {
+
+      /**
+       * Keeps a value in a ref. Useful for effectful get from a stable callback.
+       */
+      final def useShadowRef[A](value: Ctx => A)(using
+        step: Step
+      ): step.Next[NonEmptyRef.Get[A]] =
+        api.customBy { ctx =>
+          val hookInstance = hook[A]
+          hookInstance(value(ctx))
+        }
+    }
+
+    final class Secondary[Ctx, CtxFn[_], Step <: HooksApi.SubsequentStep[Ctx, CtxFn]](
+      api: HooksApi.Secondary[Ctx, CtxFn, Step]
+    ) extends Primary[Ctx, Step](api) {
+
+      /**
+       * Keeps a value in a ref. Useful for effectful get from a stable callback.
+       */
+      def useShadowRef[A](value: CtxFn[A])(using step: Step): step.Next[NonEmptyRef.Get[A]] =
+        useShadowRef(step.squash(value)(_))
+    }
+  }
+
+  protected trait HooksApiExt {
+    import HooksApiExt._
+
+    implicit def hooksExtShadowRef1[Ctx, Step <: HooksApi.AbstractStep](
+      api: HooksApi.Primary[Ctx, Step]
+    ): Primary[Ctx, Step] =
+      new Primary(api)
+
+    implicit def hooksExtShadowRef2[Ctx, CtxFn[_], Step <: HooksApi.SubsequentStep[Ctx, CtxFn]](
+      api: HooksApi.Secondary[Ctx, CtxFn, Step]
+    ): Secondary[Ctx, CtxFn, Step] =
+      new Secondary(api)
+  }
+
+  object syntax extends HooksApiExt
+}

--- a/modules/core/js/src/main/scala/crystal/react/hooks/package.scala
+++ b/modules/core/js/src/main/scala/crystal/react/hooks/package.scala
@@ -13,7 +13,8 @@ import japgolly.scalajs.react.util.DefaultEffects.Async as DefaultA
 export UseSingleEffect.syntax.*, UseSerialState.syntax.*, UseStateCallback.syntax.*,
   UseStateView.syntax.*, UseStateViewWithReuse.syntax.*, UseSerialStateView.syntax.*,
   UseAsyncEffect.syntax.*, UseEffectResult.syntax.*, UseResource.syntax.*,
-  UseStreamResource.syntax.*, UseEffectWhenDepsReady.syntax.*, UseEffectStreamResource.syntax.*
+  UseStreamResource.syntax.*, UseEffectWhenDepsReady.syntax.*, UseEffectStreamResource.syntax.*,
+  UseShadowRef.syntax.*
 
 type UnitFiber[F[_]] = Fiber[F, Throwable, Unit]
 

--- a/modules/core/js/src/main/scala/crystal/react/reuse/package.scala
+++ b/modules/core/js/src/main/scala/crystal/react/reuse/package.scala
@@ -386,7 +386,16 @@ extension [F[_]: Monad, A](rvo: Reuse[ViewOptF[F, A]])
   def mapValue[B](f: Reuse[ViewF[F, A]] => B)(using ev: Monoid[F[Unit]]): Option[B] =
     get.map(a =>
       f(
-        rvo.map(vo => ViewF[F, A](a, (mod, cb) => vo.modCB(mod, _.foldMap(cb))))
+        rvo.map(vo =>
+          ViewF[F, A](
+            a,
+            (mod, cb) =>
+              vo.modCB(
+                mod,
+                (previous, current) => (previous, current).tupled.foldMap((p, c) => cb(p, c))
+              )
+          )
+        )
       )
     )
 

--- a/modules/core/js/src/main/scala/crystal/react/syntax/view.scala
+++ b/modules/core/js/src/main/scala/crystal/react/syntax/view.scala
@@ -23,14 +23,14 @@ trait view {
   extension [F[_], A: ClassTag: Reusability](view: ViewF[F, A])
     def reuseByValue: Reuse[ViewF[F, A]] = Reuse.by(view.get)(view)
 
-  extension (viewFModule: ViewF.type) def fromState: FromStateView = new FromStateView
+  // extension (viewFModule: ViewF.type) def fromState: FromStateView = new FromStateView
 
   extension [F[_], A: ClassTag: Reusability](view: ViewOptF[F, A])
     def reuseByValue: Reuse[ViewOptF[F, A]] = Reuse.by(view.get)(view)
 
   extension [F[_]: Monad, A](optView: Option[ViewF[F, A]])
     def toViewOpt: ViewOptF[F, A] =
-      optView.fold(new ViewOptF[F, A](none, (_, cb) => cb(none)) {
+      optView.fold(new ViewOptF[F, A](none, (_, cb) => cb(none, none)) {
         override def modAndGet(f: A => A)(using F: Async[F]): F[Option[A]] = none.pure[F]
       })(_.asViewOpt)
 

--- a/modules/core/js/src/main/scala/crystal/react/syntax/view.scala
+++ b/modules/core/js/src/main/scala/crystal/react/syntax/view.scala
@@ -23,7 +23,7 @@ trait view {
   extension [F[_], A: ClassTag: Reusability](view: ViewF[F, A])
     def reuseByValue: Reuse[ViewF[F, A]] = Reuse.by(view.get)(view)
 
-  // extension (viewFModule: ViewF.type) def fromState: FromStateView = new FromStateView
+  extension (viewFModule: ViewF.type) def fromState: FromStateView = new FromStateView
 
   extension [F[_], A: ClassTag: Reusability](view: ViewOptF[F, A])
     def reuseByValue: Reuse[ViewOptF[F, A]] = Reuse.by(view.get)(view)

--- a/modules/testkit/shared/src/main/scala/crystal/arb/arbitraries.scala
+++ b/modules/testkit/shared/src/main/scala/crystal/arb/arbitraries.scala
@@ -34,7 +34,7 @@ given [A: Cogen]: Cogen[PotOption[A]] =
   Cogen[Option[Option[Option[A]]]].contramap(_.toOptionTry.map(_.toOption))
 
 given viewFArb[A: Arbitrary]: Arbitrary[ViewF[Id, A]] = Arbitrary:
-  arbitrary[A].map(a => ViewF.apply[Id, A](a, (f, cb) => cb(f(a))))
+  arbitrary[A].map(a => ViewF.apply[Id, A](a, (f, cb) => cb(a, f(a))))
 
 given [A: Cogen]: Cogen[ViewF[Id, A]] =
   Cogen[A].contramap(_.get)


### PR DESCRIPTION
The callbacks passed to `setCB`, `modCB` and `withOnMod` now have the ability to receive the previous value of the `View` as well as the new value.

This is particularly useful to implement undo with stable callbacks that don't capture values, which was shown to be tricky to avoid stale values in certain situations.

A new simple hook, `useShadowRef` is added to help with this task.

The logic of `useStreamResource` was inverted, so that state is kept in a `View` all along, instead of going through the trouble of building a new one from state (which is a bit more cumbersome now).