### PR TITLE
Impement WhenDepsReadyOrChange versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Version of `useSerialState` that returns a `Reuse[View[A]]`.
 
 ### useEffectWhenDepsReady
 
-Version of `useEffect` applicable only when there's a unique dependency of type `Pot[A]`. It will trigger the effect only when the dependency transitions to a `Ready` state, whether it was from `Pending` or `Error`. 
+Version of `useEffect` applicable only when there's a unique dependency of type `Pot[A]`. It will trigger the effect only when the dependency transitions to a `Ready` state, whether it was from `Pending` or `Error`. There are also `WhenDepsReadyOrChange` versions, which will also trigger if the dependencies change value once in `Ready` state.
 
 Note that multiple `Pot` dependencies can be combined into one with `.tupled`.
 
@@ -212,11 +212,20 @@ Note that multiple `Pot` dependencies can be combined into one with `.tupled`.
   useEffectWhenDepsReady[D](deps: => Pot[D])(effect: D => Callback)
   useEffectWhenDepsReadyBy[D](deps: Ctx => Pot[D])(effect: Ctx => D => Callback)
 
+  useEffectWhenDepsReadyOrChange[D: Reusability](deps: => Pot[D])(effect: D => Callback)
+  useEffectWhenDepsReadyOrChangeBy[D: Reusability](deps: Ctx => Pot[D])(effect: Ctx => D => Callback)
+
   useEffectWhenDepsReady[D](deps: => Pot[D])(effect: D => IO[Unit])
   useEffectWhenDepsReadyBy[D](deps: Ctx => Pot[D])(effect: Ctx => D => IO[Unit])
 
+  useEffectWhenDepsReadyOrChange[D: Reusability](deps: => Pot[D])(effect: D => IO[Unit])
+  useEffectWhenDepsReadyOrChangeBy[D: Reusability](deps: Ctx => Pot[D])(effect: Ctx => D => IO[Unit])
+
   useEffectWhenDepsReady[D](deps: => Pot[D])(effect: D => CallbackTo[Callback]) // return cleanup
   useEffectWhenDepsReadyBy[D](deps: Ctx => Pot[D])(effect: Ctx =>D => CallbackTo[Callback]) // return cleanup
+
+  useEffectWhenDepsReadyOrChange[D: Reusability](deps: => Pot[D])(effect: D => CallbackTo[Callback]) // return cleanup
+  useEffectWhenDepsReadyOrChangeBy[D: Reusability](deps: Ctx => Pot[D])(effect: Ctx =>D => CallbackTo[Callback]) // return cleanup
 ```
 
 ### useAsyncEffect
@@ -245,6 +254,11 @@ Also allows returning a cleanup effect, which `useEffect` only supports when use
   useAsyncEffectWhenDepsReady[D](deps: => Pot[D])(effect: D => IO[IO[Unit]]) // return a cleanup effect
   useAsyncEffectWhenDepsReadyBy[D](deps: Ctx => Pot[D])(effect: Ctx => D => IO[Unit])
   useAsyncEffectWhenDepsReadyBy[D](deps: Ctx => Pot[D])(effect: Ctx => D => IO[IO[Unit]]) // return a cleanup effect
+
+  useAsyncEffectWhenDepsReadyOrChange[D: Reusability](deps: => Pot[D])(effect: D => IO[Unit])
+  useAsyncEffectWhenDepsReadyOrChange[D: Reusability](deps: => Pot[D])(effect: D => IO[IO[Unit]]) // return a cleanup effect
+  useAsyncEffectWhenDepsReadyOrChangeBy[D: Reusability](deps: Ctx => Pot[D])(effect: Ctx => D => IO[Unit])
+  useAsyncEffectWhenDepsReadyOrChangeBy[D: Reusability](deps: Ctx => Pot[D])(effect: Ctx => D => IO[IO[Unit]]) // return a cleanup effect
 ```
 
 
@@ -256,7 +270,9 @@ Note that all versions either have dependencies or are executed `onMount`. It do
 
 Also note that when dependencies change, the hook value will revert to `Pending` until the new effect completes. If this is undesireable, there are `useEffectKeepResult*` variants which will instead keep the hook value as `Ready(oldValue)` until the new effect completes.
 
-There are also `WhenDepsReady` versions, which will only execute the effect when dependencies are ready. If they change or transition to `Pending` or `Error`, then the result will revert to `Pending`. However, if the `KeepResult` version is used, it will retain the last value.
+There are also `WhenDepsReady` versions, which will only execute the effect when dependencies transition to `Ready`. If they transition to `Pending` or `Error`, then the result will revert to `Pending`. However, if the `KeepResult` version is used, it will retain the last value.
+
+Furthermore, there are also `WhenDepsReadyOrChange` versions, which will only execute the effect when dependencies transition to `Ready` or change value once `Ready`. If they change or transition to `Pending` or `Error`, then the result will revert to `Pending`. However, if the `KeepResult` version is used, it will retain the last value.
 
 
 ``` scala
@@ -272,8 +288,14 @@ There are also `WhenDepsReady` versions, which will only execute the effect when
   useEffectResultWhenDepsReady[D: Reusability, A](deps: => D)(effect: D => IO[A]): Pot[A]
   useEffectResultWhenDepsReadyBy[D: Reusability, A](deps: Ctx => D)(effect: Ctx => D => IO[A]): Pot[A]
 
+  useEffectResultWhenDepsReadyOrChange[D: Reusability, A](deps: => D)(effect: D => IO[A]): Pot[A]
+  useEffectResultWhenDepsReadyOrChangeBy[D: Reusability, A](deps: Ctx => D)(effect: Ctx => D => IO[A]): Pot[A]
+
   useEffectKeepResultWhenDepsReady[D: Reusability, A](deps: => D)(effect: D => IO[A]): Pot[A]
   useEffectKeepResultWhenDepsReadyBy[D: Reusability, A](deps: Ctx => D)(effect: Ctx => D => IO[A]): Pot[A]
+
+  useEffectKeepResultWhenDepsReadyOrChange[D: Reusability, A](deps: => D)(effect: D => IO[A]): Pot[A]
+  useEffectKeepResultWhenDepsReadyOrChangeBy[D: Reusability, A](deps: Ctx => D)(effect: Ctx => D => IO[A]): Pot[A]
 ```
 
 #### Example:

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 Global / onChangedBuildSource := ReloadOnSourceChanges
 
 ThisBuild / crossScalaVersions := List("3.5.0")
-ThisBuild / tlBaseVersion      := "0.44"
+ThisBuild / tlBaseVersion      := "0.45"
 
 ThisBuild / tlCiReleaseBranches := Seq("master")
 

--- a/modules/core/js/src/main/scala/crystal/react/hooks/UseEffectWhenDepsReady.scala
+++ b/modules/core/js/src/main/scala/crystal/react/hooks/UseEffectWhenDepsReady.scala
@@ -7,7 +7,6 @@ import cats.kernel.Monoid
 import cats.syntax.all.*
 import crystal.Pot
 import crystal.react.*
-import crystal.react.syntax.pot.given
 import japgolly.scalajs.react.*
 import japgolly.scalajs.react.hooks.CustomHook
 import japgolly.scalajs.react.hooks.Hooks.UseEffectArg
@@ -15,15 +14,15 @@ import japgolly.scalajs.react.util.DefaultEffects.Async as DefaultA
 
 object UseEffectWhenDepsReady:
 
-  def hook[D, A: UseEffectArg: Monoid] =
-    CustomHook[WithPotDeps[D, A]]
-      .useEffectWithDepsBy(props => props.deps.toOption.void): props =>
+  def hook[D, A: UseEffectArg: Monoid, R: Reusability] =
+    CustomHook[WithPotDeps[D, A, R]]
+      .useEffectWithDepsBy(props => props.reuseValue): props =>
         _ => props.deps.toOption.map(props.fromDeps).orEmpty
       .build
 
-  def asyncHook[G, D](using EffectWithCleanup[G, DefaultA]) =
-    CustomHook[WithPotDeps[D, G]]
-      .useAsyncEffectWithDepsBy(props => props.deps.void): props =>
+  def asyncHook[G, D, R: Reusability](using EffectWithCleanup[G, DefaultA]) =
+    CustomHook[WithPotDeps[D, G, R]]
+      .useAsyncEffectWithDepsBy(props => props.reuseValue): props =>
         _ => props.deps.toOption.map(props.fromDeps(_).normalize).orEmpty
       .build
 
@@ -31,9 +30,24 @@ object UseEffectWhenDepsReady:
     sealed class Primary[Ctx, Step <: HooksApi.AbstractStep](api: HooksApi.Primary[Ctx, Step]) {
 
       /**
-       * Effect that runs when `Pot` dependencies transition into a `Ready` state. For multiple
-       * dependencies, use `(par1, par2, ...).tupled`. Dependencies are passed unpacked to the
-       * effect bulding function.
+       * Effect that runs whenever `Pot` dependencies transition into a `Ready` state (but not when
+       * they change once `Ready`). For multiple dependencies, use `(par1, par2, ...).tupled`.
+       * Dependencies are passed unpacked to the effect bulding function.
+       */
+      final def useEffectWhenDepsReadyBy[D, A: UseEffectArg: Monoid](
+        deps: Ctx => Pot[D]
+      )(effect: Ctx => D => A)(using
+        step: Step
+      ): step.Self =
+        api.customBy { ctx =>
+          val hookInstance = hook[D, A, Unit]
+          hookInstance(WithPotDeps.WhenReady(deps(ctx), effect(ctx)))
+        }
+
+      /**
+       * Effect that runs whenever `Pot` dependencies transition into a `Ready` state (but not when
+       * they change once `Ready`). For multiple dependencies, use `(par1, par2, ...).tupled`.
+       * Dependencies are passed unpacked to the effect bulding function.
        */
       final def useEffectWhenDepsReady[D, A: UseEffectArg: Monoid](
         deps: => Pot[D]
@@ -43,24 +57,37 @@ object UseEffectWhenDepsReady:
         useEffectWhenDepsReadyBy(_ => deps)(_ => effect)
 
       /**
-       * Effect that runs when `Pot` dependencies transition into a `Ready` state. For multiple
-       * dependencies, use `(par1, par2, ...).tupled`. Dependencies are passed unpacked to the
-       * effect bulding function.
+       * Effect that runs when `Pot` dependencies transition into a `Ready` state or change once
+       * `Ready`. For multiple dependencies, use `(par1, par2, ...).tupled`. Dependencies are passed
+       * unpacked to the effect bulding function.
        */
-      final def useEffectWhenDepsReadyBy[D, A: UseEffectArg: Monoid](
+      final def useEffectWhenDepsReadyOrChangeBy[D: Reusability, A: UseEffectArg: Monoid](
         deps: Ctx => Pot[D]
       )(effect: Ctx => D => A)(using
         step: Step
       ): step.Self =
         api.customBy { ctx =>
-          val hookInstance = hook[D, A]
-          hookInstance(WithPotDeps(deps(ctx), effect(ctx)))
+          val hookInstance = hook[D, A, D]
+          hookInstance(WithPotDeps.WhenReadyOrChange(deps(ctx), effect(ctx)))
         }
 
       /**
-       * Async effect that runs when `Pot` dependencies transition into a `Ready` state and returns
-       * a cleanup callback. For multiple dependencies, use `(par1, par2, ...).tupled`. Dependencies
-       * are passed unpacked to the effect bulding function.
+       * Effect that runs when `Pot` dependencies transition into a `Ready` state or change once
+       * `Ready`. For multiple dependencies, use `(par1, par2, ...).tupled`. Dependencies are passed
+       * unpacked to the effect bulding function.
+       */
+      final def useEffectWhenDepsReadyOrChangeBy[D: Reusability, A: UseEffectArg: Monoid](
+        deps: => Pot[D]
+      )(effect: D => A)(using
+        step: Step
+      ): step.Self =
+        useEffectWhenDepsReadyOrChangeBy(_ => deps)(_ => effect)
+
+      /**
+       * Async effect that runs whenever `Pot` dependencies transition into a `Ready` state (but not
+       * when they change once `Ready`) and returns a cleanup callback. For multiple dependencies,
+       * use `(par1, par2, ...).tupled`. Dependencies are passed unpacked to the effect bulding
+       * function.
        */
       final def useAsyncEffectWhenDepsReady[G, D](deps: => Pot[D])(effect: D => G)(using
         step: Step,
@@ -69,18 +96,49 @@ object UseEffectWhenDepsReady:
         useAsyncEffectWhenDepsReadyBy(_ => deps)(_ => effect)
 
       /**
-       * Async effect that runs when `Pot` dependencies transition into a `Ready` state and returns
-       * a cleanup callback. For multiple dependencies, use `(par1, par2, ...).tupled`. Dependencies
-       * are passed unpacked to the effect bulding function.
+       * Async effect that runs whenever `Pot` dependencies transition into a `Ready` state (but not
+       * when they change once `Ready`) and returns a cleanup callback. For multiple dependencies,
+       * use `(par1, par2, ...).tupled`. Dependencies are passed unpacked to the effect bulding
+       * function.
        */
-      final def useAsyncEffectWhenDepsReadyBy[G, D](deps: Ctx => Pot[D])(effect: Ctx => D => G)(
-        using
+      final def useAsyncEffectWhenDepsReadyBy[G, D](
+        deps: Ctx => Pot[D]
+      )(effect: Ctx => D => G)(using
         step: Step,
         G:    EffectWithCleanup[G, DefaultA]
       ): step.Self =
         api.customBy { ctx =>
-          val hookInstance = asyncHook[G, D]
-          hookInstance(WithPotDeps(deps(ctx), effect(ctx)))
+          val hookInstance = asyncHook[G, D, Unit]
+          hookInstance(WithPotDeps.WhenReady(deps(ctx), effect(ctx)))
+        }
+
+      /**
+       * Async effect that runs when `Pot` dependencies transition into a `Ready` state or change
+       * once `Ready` and returns a cleanup callback. For multiple dependencies, use `(par1, par2,
+       * ...).tupled`. Dependencies are passed unpacked to the effect bulding function.
+       */
+      final def useAsyncEffectWhenDepsReadyOrChange[G, D: Reusability](
+        deps: => Pot[D]
+      )(effect: D => G)(using
+        step: Step,
+        G:    EffectWithCleanup[G, DefaultA]
+      ): step.Self =
+        useAsyncEffectWhenDepsReadyOrChangeBy(_ => deps)(_ => effect)
+
+      /**
+       * Async effect that runs when `Pot` dependencies transition into a `Ready` state or change
+       * once `Ready` and returns a cleanup callback. For multiple dependencies, use `(par1, par2,
+       * ...).tupled`. Dependencies are passed unpacked to the effect bulding function.
+       */
+      final def useAsyncEffectWhenDepsReadyOrChangeBy[G, D: Reusability](
+        deps: Ctx => Pot[D]
+      )(effect: Ctx => D => G)(using
+        step: Step,
+        G:    EffectWithCleanup[G, DefaultA]
+      ): step.Self =
+        api.customBy { ctx =>
+          val hookInstance = asyncHook[G, D, D]
+          hookInstance(WithPotDeps.WhenReadyOrChange(deps(ctx), effect(ctx)))
         }
     }
 
@@ -89,9 +147,9 @@ object UseEffectWhenDepsReady:
     ) extends Primary[Ctx, Step](api) {
 
       /**
-       * Effect that runs when `Pot` dependencies transition into a `Ready` state. For multiple
-       * dependencies, use `(par1, par2, ...).tupled`. Dependencies are passed unpacked to the
-       * effect bulding function.
+       * Effect that runs whenever `Pot` dependencies transition into a `Ready` state (but not when
+       * they change once `Ready`). For multiple dependencies, use `(par1, par2, ...).tupled`.
+       * Dependencies are passed unpacked to the effect bulding function.
        */
       def useEffectWhenDepsReadyBy[D, A: UseEffectArg: Monoid](
         deps: CtxFn[Pot[D]]
@@ -101,15 +159,41 @@ object UseEffectWhenDepsReady:
         useEffectWhenDepsReadyBy(step.squash(deps)(_))(step.squash(effect)(_))
 
       /**
-       * Async effect that runs when `Pot` dependencies transition into a `Ready` state and returns
-       * a cleanup callback. For multiple dependencies, use `(par1, par2, ...).tupled`. Dependencies
-       * are passed unpacked to the effect bulding function.
+       * Effect that runs when `Pot` dependencies transition into a `Ready` state or change once
+       * `Ready`. For multiple dependencies, use `(par1, par2, ...).tupled`. Dependencies are passed
+       * unpacked to the effect bulding function.
+       */
+      def useEffectWhenDepsReadyOrChangeBy[D: Reusability, A: UseEffectArg: Monoid](
+        deps: CtxFn[Pot[D]]
+      )(effect: CtxFn[D => A])(using
+        step: Step
+      ): step.Self =
+        useEffectWhenDepsReadyOrChangeBy(step.squash(deps)(_))(step.squash(effect)(_))
+
+      /**
+       * Async effect that runs whenever `Pot` dependencies transition into a `Ready` state (but not
+       * when they change once `Ready`) and returns a cleanup callback. For multiple dependencies,
+       * use `(par1, par2, ...).tupled`. Dependencies are passed unpacked to the effect bulding
+       * function.
        */
       def useAsyncEffectWhenDepsReadyBy[G, D](deps: CtxFn[Pot[D]])(effect: CtxFn[D => G])(using
         step: Step,
         G:    EffectWithCleanup[G, DefaultA]
       ): step.Self =
         useAsyncEffectWhenDepsReadyBy(step.squash(deps)(_))(step.squash(effect)(_))
+
+      /**
+       * Async effect that runs when `Pot` dependencies transition into a `Ready` state or change
+       * once `Ready` and returns a cleanup callback. For multiple dependencies, use `(par1, par2,
+       * ...).tupled`. Dependencies are passed unpacked to the effect bulding function.
+       */
+      def useAsyncEffectWhenDepsReadyOrChangeBy[G, D: Reusability](
+        deps: CtxFn[Pot[D]]
+      )(effect: CtxFn[D => G])(using
+        step: Step,
+        G:    EffectWithCleanup[G, DefaultA]
+      ): step.Self =
+        useAsyncEffectWhenDepsReadyOrChangeBy(step.squash(deps)(_))(step.squash(effect)(_))
     }
   }
 


### PR DESCRIPTION
Versions of  `useEffect` and `useEffectResult` that trigger when `Pot` dependencies transition into `Ready` or when they change value once `Ready`.