### PR TITLE
Close resource when stream from useStreamResource ends

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,8 @@ In other words, when mounting or depdency change, the resource is allocated and 
 
 Upon unmount or dependency change, the evaluating fiber is cancelled and the resource closed.
 
+The resource is also closed if the stream terminates.
+
 ``` scala
   useStreamResource[D: Reusability, A](deps: => D)(streamResource: D => Resource[IO, fs2.Stream[IO, A]]): PotOption[A]
   useStreamResourceBy[D: Reusability, A](deps: Ctx => D)(streamResource: Ctx => D => Resource[IO, fs2.Stream[IO, A]]): PotOption[A]
@@ -417,7 +419,7 @@ Like the `useEffect` family of hooks, this hook doesn't add any new parameters t
 
 ### useEffectStreamResource
 
-Given a `Resource[IO, fs2.Stream[IO, Unit]]`, opens the resource and executes and drains the stream upon mount or dependency change. If still running, execution is cancelled and the resource closed upon unmount or dependency change.
+Given a `Resource[IO, fs2.Stream[IO, Unit]]`, opens the resource and executes and drains the stream upon mount or dependency change. If still running, execution is cancelled and the resource closed upon unmount or dependency change. The resource is also closed if the stream terminates.
 
 Like the `useEffect` family of hooks, this hook doesn't add any new parameters to the context.
 

--- a/modules/core/js/src/main/scala/crystal/react/hooks/UseEffectStreamResource.scala
+++ b/modules/core/js/src/main/scala/crystal/react/hooks/UseEffectStreamResource.scala
@@ -4,13 +4,13 @@
 package crystal.react.hooks
 
 import cats.effect.Resource
+import cats.effect.kernel.Deferred
 import cats.syntax.all.*
 import crystal.*
 import crystal.react.*
 import japgolly.scalajs.react.*
 import japgolly.scalajs.react.hooks.CustomHook
 import japgolly.scalajs.react.util.DefaultEffects.Async as DefaultA
-import cats.effect.kernel.Deferred
 
 object UseEffectStreamResource {
 


### PR DESCRIPTION
Turns out that closing a `Resource` is the only way to unsubscribe from a `Topic`, and when there's a loose subscriber not consuming from the `Topic` stream, it will block the whole `Topic` from publishing any new elements.

Therefore, we now close a stream resource when the stream terminates.

This is a fix for https://app.shortcut.com/lucuma/story/3434/itc-stops-after-5-configurations