### PR TITLE
Disambiguate mapValue, pending(Opt) syntax

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 Global / onChangedBuildSource := ReloadOnSourceChanges
 
-ThisBuild / crossScalaVersions := List("3.6.0")
+ThisBuild / crossScalaVersions := List("3.5.2")
 ThisBuild / tlBaseVersion      := "0.45"
 
 ThisBuild / tlCiReleaseBranches := Seq("master")

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 Global / onChangedBuildSource := ReloadOnSourceChanges
 
 ThisBuild / crossScalaVersions := List("3.5.2")
-ThisBuild / tlBaseVersion      := "0.45"
+ThisBuild / tlBaseVersion      := "0.46"
 
 ThisBuild / tlCiReleaseBranches := Seq("master")
 

--- a/modules/core/shared/src/main/scala/crystal/syntax.scala
+++ b/modules/core/shared/src/main/scala/crystal/syntax.scala
@@ -6,7 +6,10 @@ package crystal
 import scala.annotation.targetName
 import scala.util.Try
 
-trait syntax {
+trait syntax:
+  def pending[A]: Pot[A]          = Pot.Pending
+  def pendingOpt[A]: PotOption[A] = PotOption.Pending
+
   extension [A](a: A)
     def ready: Pot[A]           = Pot.Ready(a)
     def readySome: PotOption[A] = PotOption.ReadySome(a)
@@ -28,7 +31,5 @@ trait syntax {
     def toPot: Pot[A]             = Pot.fromTry[A](a)
     @targetName("tryToPotOption")
     def toPotOption: PotOption[A] = PotOption.fromTry(a)
-
-}
 
 object syntax extends syntax

--- a/modules/core/shared/src/main/scala/crystal/viewF.scala
+++ b/modules/core/shared/src/main/scala/crystal/viewF.scala
@@ -14,8 +14,6 @@ import monocle.Optional
 import monocle.Prism
 import monocle.Traversal
 
-import scala.annotation.targetName
-
 sealed abstract class ViewOps[F[_]: Monad, G[_], A] {
   val get: G[A]
 
@@ -131,25 +129,23 @@ class ViewF[F[_]: Monad, A](val get: A, val modCB: (A => A, (A, A) => F[Unit]) =
   def toOptionView[B](using ev: A =:= Option[B]): Option[ViewF[F, B]] =
     mapValue[B, ViewF[F, B]](identity)
 
-  @targetName("mapValuePot")
-  def mapValue[B, C](f: ViewF[F, B] => C)(using ev: A =:= Pot[B]): Pot[C] =
+  def mapValuePot[B, C](f: ViewF[F, B] => C)(using ev: A =:= Pot[B]): Pot[C] =
     // _.get is safe here since it's only being called when the value is defined.
     // The zoom getter function is stored to use in callbacks, so we have to pass _.get
     // instead of capturing the value here. Otherwise, callbacks see a stale value.
     get.map(_ => f(zoom(_.toOption.get)(f => a1 => ev.flip(a1.map(f)))))
 
   def toPotView[B](using ev: A =:= Pot[B]): Pot[ViewF[F, B]] =
-    mapValue[B, ViewF[F, B]](identity)
+    mapValuePot[B, ViewF[F, B]](identity)
 
-  @targetName("mapValuePotOption")
-  def mapValue[B, C](f: ViewF[F, B] => C)(using ev: A =:= PotOption[B]): PotOption[C] =
+  def mapValuePotOption[B, C](f: ViewF[F, B] => C)(using ev: A =:= PotOption[B]): PotOption[C] =
     // _.get is safe here since it's only being called when the value is defined.
     // The zoom getter function is stored to use in callbacks, so we have to pass _.get
     // instead of capturing the value here. Otherwise, callbacks see a stale value.
     get.map(_ => f(zoom(_.toOption.get)(f => a1 => ev.flip(a1.map(f)))))
 
   def toPotOptionView[B](using ev: A =:= PotOption[B]): PotOption[ViewF[F, B]] =
-    mapValue[B, ViewF[F, B]](identity)
+    mapValuePotOption[B, ViewF[F, B]](identity)
 
   def when(cond: A => Boolean): Boolean = cond(get)
 

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -13,7 +13,7 @@ object Settings {
     val log4Cats        = "2.7.0"
     val lucumaReact     = "0.71.3"
     val monocle         = "3.3.0"
-    val mUnit           = "1.0.2"
+    val mUnit           = "1.0.3"
     val mUnitScalacheck = "1.0.0"
     val mUnitCatsEffect = "2.0.0"
     val scalaCheck      = "1.18.1"


### PR DESCRIPTION
- `mapValue` was overloaded for `Option`, `Pot` and `PotOption`. This caused the compiler to be unable to disambiguate in cases where the type was not explicit. Now we rename to reflect the type.
- Adding `pending` and `pendingOpt` to `syntax`, similar to `none` but for `Pot` and `PotOption`.

Dial down Scala version.