### PR TITLE
Effect Throttler

### DIFF
--- a/modules/core/js/src/main/scala/crystal/react/hooks/UseSingleEffect.scala
+++ b/modules/core/js/src/main/scala/crystal/react/hooks/UseSingleEffect.scala
@@ -50,7 +50,7 @@ class UseSingleEffect[F[_]](
 
   // There's no need to clean up the fiber reference once the effect completes.
   // Worst case scenario, cancel will be called on it, which will do nothing.
-  def submit[G](effect: G)(using EffectWithCleanup[G, F]) =
+  def submit[G](effect: G)(using EffectWithCleanup[G, F]): F[Unit] =
     switchTo(effect.normalize)
 
 object UseSingleEffect:

--- a/modules/core/shared/src/main/scala/crystal/Throttler.scala
+++ b/modules/core/shared/src/main/scala/crystal/Throttler.scala
@@ -1,0 +1,42 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package crystal
+
+import cats.Monoid
+import cats.effect.Ref
+import cats.effect.Sync
+import cats.effect.Temporal
+import cats.effect.syntax.all.given
+import cats.syntax.all.*
+
+import scala.concurrent.duration.FiniteDuration
+
+/**
+ * Throttles submitted effects so that they are spaced by at least the specified time. Effects will
+ * be discarded if they are submitted while another effect is running, except for the last one.
+ */
+class Throttler[F[_]: Temporal] private (
+  spacedBy:  FiniteDuration,
+  isRunning: Ref[F, Boolean], // true if an effect is running
+  queued:    Ref[F, Option[F[Unit]]]
+)(using Monoid[F[Unit]]):
+  def submit(f: F[Unit]): F[Unit] =
+    (queued.set(none) >> isRunning.getAndSet(true)).uncancelable
+      .flatMap:
+        case false =>
+          Temporal[F].sleep(spacedBy).both(f) >> // Completes when both complete.
+            (isRunning.set(false) >> queued.getAndSet(none)).uncancelable
+              .flatMap(_.map(submit).orEmpty)
+        case true  =>
+          queued.set(f.some)
+
+object Throttler:
+  def apply[F[_]: Temporal](spacedBy: FiniteDuration)(using Monoid[F[Unit]]): F[Throttler[F]] =
+    for
+      isRunning <- Ref.of(false)
+      queued    <- Ref.of(none)
+    yield new Throttler(spacedBy, isRunning, queued)
+
+  def unsafe[F[_]: Temporal: Sync](spacedBy: FiniteDuration)(using Monoid[F[Unit]]): Throttler[F] =
+    new Throttler(spacedBy, Ref.unsafe(false), Ref.unsafe(none))

--- a/modules/tests/shared/src/test/scala/crystal/DeglitcherSpec.scala
+++ b/modules/tests/shared/src/test/scala/crystal/DeglitcherSpec.scala
@@ -11,14 +11,13 @@ import munit.CatsEffectSuite
 
 import scala.concurrent.duration.*
 
-class DeglitcherSuite extends CatsEffectSuite {
+class DeglitcherSpec extends CatsEffectSuite:
 
   def server[A](values: (A, FiniteDuration)*): Stream[IO, A] =
     Stream
       .emits(values)
-      .evalMap { (a, t) =>
+      .evalMap: (a, t) =>
         IO.sleep(t).as(a)
-      }
       .prefetchN(Int.MaxValue)
 
   test("emits elements immediately if unthrottled") {
@@ -74,5 +73,3 @@ class DeglitcherSuite extends CatsEffectSuite {
       }
       .assertEquals(List(0 -> 150.millis))
   }
-
-}

--- a/modules/tests/shared/src/test/scala/crystal/ThrottlerSpec.scala
+++ b/modules/tests/shared/src/test/scala/crystal/ThrottlerSpec.scala
@@ -1,0 +1,122 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package crystal
+
+import cats.effect.IO
+import cats.effect.Ref
+import cats.effect.testkit.TestControl
+import cats.syntax.all.*
+import munit.CatsEffectSuite
+
+import scala.concurrent.duration.*
+
+class ThrottlerSpec extends CatsEffectSuite:
+
+  def server(
+    spacedBy: FiniteDuration,
+    values:   (FiniteDuration, FiniteDuration)*
+  ): IO[List[(FiniteDuration, FiniteDuration)]] =
+    for
+      throttler <- Throttler[IO](spacedBy)
+      ref       <- Ref[IO].of(List.empty[(FiniteDuration, FiniteDuration)])
+      _         <- values.toList.parTraverse: (delay, duration) =>
+                     IO.sleep(delay) >> throttler.submit:
+                       for
+                         start <- IO.realTime
+                         _     <- IO.sleep(duration)
+                         end   <- IO.realTime
+                         _     <- ref.update(_ :+ (start, end))
+                       yield ()
+      result    <- ref.get
+    yield result
+
+  test("behaves normally if submissions are spaced by threshold or more"):
+    TestControl.executeEmbed:
+      server(
+        100.millis,
+        (100.millis, 10.millis),
+        (200.millis, 10.millis),
+        (310.millis, 10.millis)
+      ).assertEquals(
+        List(
+          (100.millis, 110.millis),
+          (200.millis, 210.millis),
+          (310.millis, 320.millis)
+        )
+      )
+
+  test("delays single effects that are spaced by less than threshold"):
+    TestControl.executeEmbed:
+      server(
+        100.millis,
+        (100.millis, 10.millis),
+        (150.millis, 10.millis),
+        (201.millis, 10.millis)
+      ).assertEquals(
+        List(
+          (100.millis, 110.millis),
+          (200.millis, 210.millis),
+          (300.millis, 310.millis)
+        )
+      )
+
+  test("drops multiple effects that are spaced by less than threshold"):
+    TestControl.executeEmbed:
+      server(
+        100.millis,
+        (100.millis, 10.millis),
+        (150.millis, 10.millis), // dropped
+        (160.millis, 20.millis), // dropped
+        (170.millis, 30.millis), // executed
+        (201.millis, 10.millis), // dropped
+        (220.millis, 20.millis), // dropped
+        (290.millis, 30.millis)  // executed
+      ).assertEquals(
+        List(
+          (100.millis, 110.millis),
+          (200.millis, 230.millis),
+          (300.millis, 330.millis)
+        )
+      )
+
+  test("drops multiple effects that are submitted while effect is running"):
+    TestControl.executeEmbed:
+      server(
+        10.millis,
+        (100.millis, 100.millis),
+        (150.millis, 110.millis), // dropped
+        (160.millis, 120.millis), // dropped
+        (170.millis, 130.millis), // executed
+        (201.millis, 100.millis), // dropped
+        (220.millis, 120.millis), // dropped
+        (290.millis, 130.millis)  // executed
+      ).assertEquals(
+        List(
+          (100.millis, 200.millis),
+          (200.millis, 330.millis),
+          (330.millis, 460.millis)
+        )
+      )
+
+  test(
+    "drops multiple effects that are submitted while effect is running or spaced less than threshold"
+  ):
+    TestControl.executeEmbed:
+      server(
+        100.millis,
+        (100.millis, 80.millis),
+        (150.millis, 110.millis), // dropped
+        (160.millis, 120.millis), // dropped
+        (190.millis, 130.millis), // dropped
+        (195.millis, 140.millis), // executed
+        (201.millis, 100.millis), // dropped
+        (220.millis, 120.millis), // dropped
+        (290.millis, 130.millis)  // executed
+      ).assertEquals(
+        List(
+          (100.millis, 180.millis),
+          (200.millis, 340.millis),
+          (340.millis, 470.millis)
+        )
+      )


### PR DESCRIPTION
Adds a `Throttler` that spaces submitted effects by a specified time.

If multiple effects are submitted while an effect is running or during the buffer time, all except the last one will be dropped.

Useful to avoid overwhelming the server when making queries in response to external events.