### PR TITLE
Avoid blocking the fiber when submitting a throttled effect

### DIFF
--- a/modules/core/shared/src/main/scala/crystal/Throttler.scala
+++ b/modules/core/shared/src/main/scala/crystal/Throttler.scala
@@ -25,9 +25,9 @@ class Throttler[F[_]: Temporal] private (
     (queued.set(none) >> isRunning.getAndSet(true)).uncancelable
       .flatMap:
         case false =>
-          Temporal[F].sleep(spacedBy).both(f) >> // Completes when both complete.
+          (Temporal[F].sleep(spacedBy).both(f) >> // Completes when both complete.
             (isRunning.set(false) >> queued.getAndSet(none)).uncancelable
-              .flatMap(_.map(submit).orEmpty)
+              .flatMap(_.map(submit).orEmpty)).start.void // Execute everything in background.
         case true  =>
           queued.set(f.some)
 

--- a/modules/tests/shared/src/test/scala/crystal/ThrottlerSpec.scala
+++ b/modules/tests/shared/src/test/scala/crystal/ThrottlerSpec.scala
@@ -16,107 +16,101 @@ class ThrottlerSpec extends CatsEffectSuite:
   def server(
     spacedBy: FiniteDuration,
     values:   (FiniteDuration, FiniteDuration)*
-  ): IO[List[(FiniteDuration, FiniteDuration)]] =
+  ): IO[Ref[IO, List[(FiniteDuration, FiniteDuration)]]] =
     for
       throttler <- Throttler[IO](spacedBy)
       ref       <- Ref[IO].of(List.empty[(FiniteDuration, FiniteDuration)])
       _         <- values.toList.parTraverse: (delay, duration) =>
-                     IO.sleep(delay) >> throttler.submit:
-                       for
-                         start <- IO.realTime
-                         _     <- IO.sleep(duration)
-                         end   <- IO.realTime
-                         _     <- ref.update(_ :+ (start, end))
-                       yield ()
-      result    <- ref.get
-    yield result
+                     IO.sleep(delay) >>
+                       throttler.submit:
+                         for
+                           start <- IO.realTime
+                           _     <- IO.sleep(duration)
+                           end   <- IO.realTime
+                           _     <- ref.update(_ :+ (start, end))
+                         yield ()
+    yield ref
+
+  def testSequence(
+    spacedBy: FiniteDuration,
+    values:   (FiniteDuration, FiniteDuration)*
+  )(expected: (FiniteDuration, FiniteDuration)*): IO[Unit] =
+    TestControl
+      .executeEmbed(server(spacedBy, values*))
+      .flatMap(_.get)
+      .assertEquals(expected)
 
   test("behaves normally if submissions are spaced by threshold or more"):
-    TestControl.executeEmbed:
-      server(
-        100.millis,
-        (100.millis, 10.millis),
-        (200.millis, 10.millis),
-        (310.millis, 10.millis)
-      ).assertEquals(
-        List(
-          (100.millis, 110.millis),
-          (200.millis, 210.millis),
-          (310.millis, 320.millis)
-        )
-      )
+    testSequence(
+      100.millis,
+      (100.millis, 10.millis),
+      (200.millis, 10.millis),
+      (310.millis, 10.millis)
+    )(
+      (100.millis, 110.millis),
+      (200.millis, 210.millis),
+      (310.millis, 320.millis)
+    )
 
   test("delays single effects that are spaced by less than threshold"):
-    TestControl.executeEmbed:
-      server(
-        100.millis,
-        (100.millis, 10.millis),
-        (150.millis, 10.millis),
-        (201.millis, 10.millis)
-      ).assertEquals(
-        List(
-          (100.millis, 110.millis),
-          (200.millis, 210.millis),
-          (300.millis, 310.millis)
-        )
-      )
+    testSequence(
+      100.millis,
+      (100.millis, 10.millis),
+      (150.millis, 10.millis),
+      (201.millis, 10.millis)
+    )(
+      (100.millis, 110.millis),
+      (200.millis, 210.millis),
+      (300.millis, 310.millis)
+    )
 
   test("drops multiple effects that are spaced by less than threshold"):
-    TestControl.executeEmbed:
-      server(
-        100.millis,
-        (100.millis, 10.millis),
-        (150.millis, 10.millis), // dropped
-        (160.millis, 20.millis), // dropped
-        (170.millis, 30.millis), // executed
-        (201.millis, 10.millis), // dropped
-        (220.millis, 20.millis), // dropped
-        (290.millis, 30.millis)  // executed
-      ).assertEquals(
-        List(
-          (100.millis, 110.millis),
-          (200.millis, 230.millis),
-          (300.millis, 330.millis)
-        )
-      )
+    testSequence(
+      100.millis,
+      (100.millis, 10.millis),
+      (150.millis, 10.millis), // dropped
+      (160.millis, 20.millis), // dropped
+      (170.millis, 30.millis), // executed
+      (201.millis, 10.millis), // dropped
+      (220.millis, 20.millis), // dropped
+      (290.millis, 30.millis)  // executed
+    )(
+      (100.millis, 110.millis),
+      (200.millis, 230.millis),
+      (300.millis, 330.millis)
+    )
 
   test("drops multiple effects that are submitted while effect is running"):
-    TestControl.executeEmbed:
-      server(
-        10.millis,
-        (100.millis, 100.millis),
-        (150.millis, 110.millis), // dropped
-        (160.millis, 120.millis), // dropped
-        (170.millis, 130.millis), // executed
-        (201.millis, 100.millis), // dropped
-        (220.millis, 120.millis), // dropped
-        (290.millis, 130.millis)  // executed
-      ).assertEquals(
-        List(
-          (100.millis, 200.millis),
-          (200.millis, 330.millis),
-          (330.millis, 460.millis)
-        )
-      )
+    testSequence(
+      10.millis,
+      (100.millis, 100.millis),
+      (150.millis, 110.millis), // dropped
+      (160.millis, 120.millis), // dropped
+      (170.millis, 130.millis), // executed
+      (201.millis, 100.millis), // dropped
+      (220.millis, 120.millis), // dropped
+      (290.millis, 130.millis)  // executed
+    )(
+      (100.millis, 200.millis),
+      (200.millis, 330.millis),
+      (330.millis, 460.millis)
+    )
 
   test(
     "drops multiple effects that are submitted while effect is running or spaced less than threshold"
   ):
-    TestControl.executeEmbed:
-      server(
-        100.millis,
-        (100.millis, 80.millis),
-        (150.millis, 110.millis), // dropped
-        (160.millis, 120.millis), // dropped
-        (190.millis, 130.millis), // dropped
-        (195.millis, 140.millis), // executed
-        (201.millis, 100.millis), // dropped
-        (220.millis, 120.millis), // dropped
-        (290.millis, 130.millis)  // executed
-      ).assertEquals(
-        List(
-          (100.millis, 180.millis),
-          (200.millis, 340.millis),
-          (340.millis, 470.millis)
-        )
-      )
+    testSequence(
+      100.millis,
+      (100.millis, 80.millis),
+      (150.millis, 110.millis), // dropped
+      (160.millis, 120.millis), // dropped
+      (190.millis, 130.millis), // dropped
+      (195.millis, 140.millis), // executed
+      (201.millis, 100.millis), // dropped
+      (220.millis, 120.millis), // dropped
+      (290.millis, 130.millis)  // executed
+    )(
+      (100.millis, 180.millis),
+      (200.millis, 340.millis),
+      (340.millis, 470.millis)
+    )


### PR DESCRIPTION
The `Throttler` would block the current fiber when `submit`ting an effect to it, until both the effect and the timeout had completed. This PR fixes the issue by spawning a new fiber where to execute it and wait for the timeout. 